### PR TITLE
Fixed Teamwork Time entries empty response

### DIFF
--- a/src/Response/JSON.php
+++ b/src/Response/JSON.php
@@ -86,7 +86,7 @@ class JSON extends Model
                             }
                             $source = $_source;
                         } elseif (
-                            strpos($headers['X-Action'], 'time_entries') > 0 &&
+                            strpos($headers['X-Action'], 'time_entries') !==FALSE &&
                             !$source
                         ) {
                             $source = [];


### PR DESCRIPTION
I found a bug while developing using your library.

If time entries return null result then the condition you wrote do not work. Correct condition when using strpos is "!== FASLE" and not >0

Would be great if you can update the repository and composer